### PR TITLE
fix: chinese input method enter

### DIFF
--- a/components/Chat/index.tsx
+++ b/components/Chat/index.tsx
@@ -231,6 +231,7 @@ const Chat = () => {
                   setText(e.target.value)
                 }}
                 onKeyDown={e => {
+                  if (e.nativeEvent.isComposing) return
                   if (e.key === 'Enter') {
                     e.preventDefault();
                     sendChat();


### PR DESCRIPTION
Change-Id: I29bcc639e5751bec8f1ba45d1daea6a88edc4f25
When using Chinese Input Method, press down the "enter" key will send a chat, fixed this problem. 
why I use `e.nativeEvent`:  [facebook/react/issues/13104](https://github.com/facebook/react/issues/13104)